### PR TITLE
fix getWorkingTag

### DIFF
--- a/nifi-gradle-built-example-nar/build.gradle
+++ b/nifi-gradle-built-example-nar/build.gradle
@@ -52,5 +52,5 @@ def getWorkingRevision() {
 }
 
 def getWorkingTag() {
-    grgit.tag.list()[0] ?: 'HEAD'
+    grgit.tag.list()[0]?.fullName ?: 'HEAD'
 }


### PR DESCRIPTION
Without this change is the tag exists (i.e. the function doen't default to 'HEAD') the tag in `<nar>/META-INF/MANIFEST.MF` will have the following format:
```
Build-Tag: org.ajoberstar.grgit.Tag(org.ajoberstar.grgit.Commit(2595c4
 35e01957a27eafa8af036086bd880c10f1, 2595c43, [60da3a7ae6b36397837d81a
 dd23fdde19105c5be], org.ajoberstar.grgit.Person(Artur Mostowski, artu
 r.mostowski@protonmail.com), org.ajoberstar.grgit.Person(Artur Mostow
 ski, artur.mostowski@protonmail.com), 2025-03-10T23:27:22+01:00[GMT+0
 1:00], ci setup
, ci setup, Mon Mar 10 23:27:22 CET 2025, 1741645642)
 , null, refs/tags/0.1.0, null, null, null, 0.1.0)
 ```
 Which is invalid.
 
 With this change it becomes:
 `Build-Tag: refs/tags/0.1.0`
 
 By the way, thank you a thousend-fold for this repo. It will improve dev experience of a few people who were writing Invoked Scripted Processors until now.